### PR TITLE
sender_id is now kept

### DIFF
--- a/rasa/graph_components/converters/nlu_message_converter.py
+++ b/rasa/graph_components/converters/nlu_message_converter.py
@@ -41,6 +41,7 @@ class NLUMessageConverter(GraphComponent):
                     TEXT: message.text,
                     "message_id": message.message_id,
                     "metadata": message.metadata,
+                    "sender_id": message.sender_id,
                 },
                 output_properties={TEXT_TOKENS},
             )


### PR DESCRIPTION
Solves #10717

**Proposed changes**:
- nlu_message_converter now keeps the sender_id in the messages that passes to the next components

**Status (please check what you already did)**:
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)